### PR TITLE
Use stable FFmpeg build

### DIFF
--- a/lib/membrane_precompiled_dependency_provider.ex
+++ b/lib/membrane_precompiled_dependency_provider.ex
@@ -34,10 +34,10 @@ defmodule Membrane.PrecompiledDependencyProvider do
         nil
 
       %{architecture: "aarch64", os: "linux"} ->
-        "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n6.1-latest-linuxarm64-gpl-shared-6.1.tar.xz"
+        "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2023-11-30-12-55/ffmpeg-n6.0.1-linuxarm64-gpl-shared-6.0.tar.xz"
 
       %{os: "linux"} ->
-        "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n6.1-latest-linux64-gpl-shared-6.1.tar.xz"
+        "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2023-11-30-12-55/ffmpeg-n6.0.1-linux64-gpl-shared-6.0.tar.xz"
 
       %{architecture: "x86_64", os: "darwin" <> _rest_of_os_name} ->
         "#{url_prefix}_macos_intel.tar.gz"


### PR DESCRIPTION
I locked FFmpeg to the last build from November as it is guaranteed to be preserved for 2 years.

Take a look at https://github.com/BtbN/FFmpeg-Builds?tab=readme-ov-file#release-retention-policy