### PR TITLE
Fix Apache license SPDX identifier in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Membrane.PrecompiledDependencyProvider.MixProject do
   defp package do
     [
       maintainers: ["Membrane Team"],
-      licenses: ["Apache 2.0"],
+      licenses: ["Apache-2.0"],
       links: %{
         "GitHub" => @github_url,
         "Membrane Framework Homepage" => "https://membraneframework.org"


### PR DESCRIPTION
Changes `licenses: ["Apache 2.0"]` to `licenses: ["Apache-2.0"]` to use the correct [SPDX identifier](https://spdx.org/licenses/Apache-2.0.html).