### PR TITLE
Replace stale FFmpeg static build link with long-living ones. Bump to v0.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The package can be installed by adding `membrane_precompiled_dependency_provider
 ```elixir
 def deps do
   [
-    {:membrane_precompiled_dependency_provider, "~> 0.2.3"}
+    {:membrane_precompiled_dependency_provider, "~> 0.2.4"}
   ]
 end
 ```

--- a/lib/membrane_precompiled_dependency_provider.ex
+++ b/lib/membrane_precompiled_dependency_provider.ex
@@ -137,14 +137,11 @@ defmodule Membrane.PrecompiledDependencyProvider do
       version in ["6.1", "6.1.3"] ->
         "#{@ffmpeg_builds_url}/download/autobuild-2025-08-31-13-00/ffmpeg-n6.1.3-#{platform}-gpl-shared-6.1.tar.xz"
 
-      version in ["7.0", "7.0.2"] ->
-        "#{@ffmpeg_builds_url}/download/autobuild-2024-08-31-12-50/ffmpeg-n7.0.2-6-g7e69129d2f-#{platform}-gpl-shared-7.0.tar.xz"
-
       version in ["7.1", "7.1.2"] ->
-        "#{@ffmpeg_builds_url}/download/autobuild-2025-09-23-13-17/ffmpeg-n7.1.2-2-gab05459692-#{platform}-gpl-shared-7.1.tar.xz"
+        "#{@ffmpeg_builds_url}/download/autobuild-2025-09-30-13-19/ffmpeg-n7.1.2-5-g8f77695e65-#{platform}-gpl-shared-7.1.tar.xz"
 
       version == "8.0" ->
-        "#{@ffmpeg_builds_url}/download/autobuild-2025-09-23-13-17/ffmpeg-n8.0-14-gb9adbf0fcc-#{platform}-gpl-shared-8.0.tar.xz"
+        "#{@ffmpeg_builds_url}/download/autobuild-2025-09-30-13-19/ffmpeg-n8.0-16-gd8605a6b55-#{platform}-gpl-shared-8.0.tar.xz"
 
       version == "latest" ->
         "#{@ffmpeg_builds_url}/latest/download/ffmpeg-master-latest-#{platform}-gpl-shared.tar.xz"

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.PrecompiledDependencyProvider.MixProject do
   use Mix.Project
 
-  @version "0.2.3"
+  @version "0.2.4"
   @github_url "https://github.com/membraneframework/membrane_precompiled_dependency_provider"
 
   def project do


### PR DESCRIPTION
This PR closes https://github.com/membraneframework/membrane_precompiled_dependency_provider/issues/15

Warning - it removes support for FFmpeg 7.0 linux builds as they are no longer available in BtbN artifacts